### PR TITLE
fix: safer working with undefined context

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -105,7 +105,7 @@ Creates an iterator which iterates and rdf:List of the current term
 <a name="Clownface+toArray"></a>
 
 ### clownface.toArray() ⇒ [<code>Array.&lt;Clownface&gt;</code>](#Clownface)
-Returns an array of graph pointers where each on has a single _context
+Returns an array of graph pointers where each one has a single _context
 
 **Kind**: instance method of [<code>Clownface</code>](#Clownface)  
 <a name="Clownface+filter"></a>

--- a/lib/Clownface.js
+++ b/lib/Clownface.js
@@ -149,12 +149,14 @@ class Clownface {
   }
 
   /**
-   * Returns an array of graph pointers where each on has a single _context
+   * Returns an array of graph pointers where each one has a single _context
    *
    * @returns {Clownface[]}
    */
   toArray () {
-    return this._context.map(context => Clownface.fromContext(context))
+    return this._context
+      .map(context => Clownface.fromContext(context))
+      .filter(context => context.terms.some(Boolean))
   }
 
   /**

--- a/lib/Context.js
+++ b/lib/Context.js
@@ -36,13 +36,15 @@ class Context {
   addIn (predicates, subjects) {
     const context = []
 
-    subjects.forEach(subject => {
-      predicates.forEach(predicate => {
-        this.dataset.add(this.factory.quad(subject, predicate, this.term, this.graph))
-      })
+    if (this.term) {
+      subjects.forEach(subject => {
+        predicates.forEach(predicate => {
+          this.dataset.add(this.factory.quad(subject, predicate, this.term, this.graph))
+        })
 
-      context.push(this.clone({ value: subject }))
-    })
+        context.push(this.clone({ value: subject }))
+      })
+    }
 
     return context
   }
@@ -50,18 +52,24 @@ class Context {
   addOut (predicates, objects) {
     const context = []
 
-    objects.forEach(object => {
-      predicates.forEach(predicate => {
-        this.dataset.add(this.factory.quad(this.term, predicate, object, this.graph))
-      })
+    if (this.term) {
+      objects.forEach(object => {
+        predicates.forEach(predicate => {
+          this.dataset.add(this.factory.quad(this.term, predicate, object, this.graph))
+        })
 
-      context.push(this.clone({ value: object }))
-    })
+        context.push(this.clone({ value: object }))
+      })
+    }
 
     return context
   }
 
   addList (predicates, items) {
+    if (!this.term) {
+      return
+    }
+
     predicates.forEach(predicate => {
       const nodes = items.map(() => this.factory.blankNode())
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "rdf-dataset-ext": "^1.0.0",
     "rdf-ext": "^1.3.0",
     "rimraf": "^3.0.2",
+    "sinon": "^9.0.2",
     "standard": "^12.0.1",
     "tbbt-ld": "^1.1.0"
   },

--- a/test/Clownface/addList.js
+++ b/test/Clownface/addList.js
@@ -1,5 +1,4 @@
-/* global describe, it */
-
+const { describe, it } = require('mocha')
 const assert = require('assert')
 const clownface = require('../..')
 const rdf = require('../support/factory')
@@ -106,5 +105,15 @@ describe('.addList', () => {
     assert.strictEqual(first0.predicate.testProperty, 'test')
     assert.strictEqual(rest0.testProperty, 'test')
     assert.strictEqual(rest0.predicate.testProperty, 'test')
+  })
+
+  it('should not add quads if context is undefined', () => {
+    const dataset = rdf.dataset()
+    const graph = clownface({ dataset })
+    const predicate = rdf.namedNode('http://example.org/foo')
+
+    graph.addList(predicate, ['bar', 'baz'])
+
+    assert.strictEqual(dataset.size, 0)
   })
 })

--- a/test/Clownface/addOut.js
+++ b/test/Clownface/addOut.js
@@ -1,6 +1,6 @@
-/* global describe, it */
-
+const { describe, it } = require('mocha')
 const assert = require('assert')
+const sinon = require('sinon')
 const clownface = require('../..')
 const loadExample = require('../support/example')
 const rdf = require('../support/factory')
@@ -168,6 +168,7 @@ describe('.addOut', () => {
   it('should use the provided factory', () => {
     const dataset = rdf.dataset()
     const predicate = rdf.namedNode('http://schema.org/knows')
+    const term = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
     const factory = {
       quad: (s, p, o, g) => {
         const quad = rdf.quad(s, p, o, g)
@@ -186,11 +187,34 @@ describe('.addOut', () => {
       }
     }
 
-    const cf = clownface({ dataset, factory }).addOut(predicate, 'test')
+    const cf = clownface({ dataset, factory, term }).addOut(predicate, 'test')
 
     assert.strictEqual(cf.out(predicate).term.testProperty, 'test')
     cf.dataset.match(null, predicate, null).forEach((quad) => {
       assert.strictEqual(quad.testProperty, 'test')
     })
+  })
+
+  it('should not add quads if context is undefined', () => {
+    const dataset = rdf.dataset()
+    const cf = clownface({ dataset })
+    const object = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    const predicate = rdf.namedNode('http://schema.org/knows')
+
+    cf.addOut(predicate, object)
+
+    assert.strictEqual(dataset.size, 0)
+  })
+
+  it('should not call callback function if context is undefined', () => {
+    const dataset = rdf.dataset()
+    const cf = clownface({ dataset })
+    const object = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    const predicate = rdf.namedNode('http://schema.org/knows')
+    const callback = sinon.spy()
+
+    cf.addOut(predicate, object, callback)
+
+    assert.strictEqual(callback.called, false)
   })
 })

--- a/test/Clownface/toArray.js
+++ b/test/Clownface/toArray.js
@@ -30,4 +30,12 @@ describe('.toArray', () => {
     assert.strictEqual(result.length, 7)
     assert(result[0] instanceof Clownface)
   })
+
+  it('should not return an instance for undefined context', () => {
+    const cf = clownface({ dataset: rdf.dataset() })
+
+    const array = cf.toArray()
+
+    assert.strictEqual(array.length, 0)
+  })
 })


### PR DESCRIPTION
fixes #33 

There are two changes to the behaviour of a Clownface object initialised without a term

1. The `add*` methods will not create any quads
2. No callbacks will be called for `add*`
2. `toArray` will come back empty