### PR TITLE
fix: mixing clownface version breaks on language

### DIFF
--- a/lib/Context.js
+++ b/lib/Context.js
@@ -28,7 +28,7 @@ class Context {
     })
   }
 
-  out (predicate, { language }) {
+  out (predicate, { language } = {}) {
     let objects = this.matchProperty(toArray(this.term), predicate, null, toArray(this.graph), 'object')
 
     if (typeof language !== 'undefined') {

--- a/test/Context.js
+++ b/test/Context.js
@@ -1,0 +1,17 @@
+const { describe, it } = require('mocha')
+const assert = require('assert')
+const { schema } = require('@tpluscode/rdf-ns-builders')
+const Context = require('../lib/Context')
+const rdf = require('./support/factory')
+
+describe('Context', () => {
+  describe('out', () => {
+    it('can be called without language', () => {
+      const context = new Context({ dataset: rdf.dataset() })
+
+      assert.doesNotThrow(() => {
+        context.out(schema.knows)
+      })
+    })
+  })
+})


### PR DESCRIPTION
This fixes a subtle problem which arises from multiple versions of clownface (0.12 & 1.0) which might be installed through incompatible transitive dependencies

Version 0.12 does not have languages and thus will call `Context#out` without the second parameter. It does not have a default value and will thus fail to restructure when `undefined`