### PR TITLE
feat: accept Iterator as argument to create pointer nodes

### DIFF
--- a/lib/toArray.js
+++ b/lib/toArray.js
@@ -3,15 +3,15 @@ function toArray (value, defaultValue) {
     return defaultValue
   }
 
+  if (Array.isArray(value)) {
+    return value
+  }
+
   if (typeof value !== 'string' && value[Symbol.iterator]) {
     return [...value]
   }
 
-  if (!Array.isArray(value)) {
-    return [value]
-  }
-
-  return value
+  return [value]
 }
 
 module.exports = toArray

--- a/lib/toArray.js
+++ b/lib/toArray.js
@@ -3,6 +3,10 @@ function toArray (value, defaultValue) {
     return defaultValue
   }
 
+  if (typeof value !== 'string' && value[Symbol.iterator]) {
+    return [...value]
+  }
+
   if (!Array.isArray(value)) {
     return [value]
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@rdfjs/parser-n3": "^1.1.2",
+    "@rdfjs/term-set": "^1.0.1",
     "docsify-cli": "^4.4.0",
     "husky": "^4.2.5",
     "jsdoc-to-markdown": "^5.0.3",

--- a/test/Clownface/blankNode.js
+++ b/test/Clownface/blankNode.js
@@ -63,4 +63,18 @@ describe('.blankNode', () => {
     assert.strictEqual(result._context[1].term.termType, 'BlankNode')
     assert.strictEqual(result._context[1].term.value, labelB)
   })
+
+  it('should support multiple values in an iterable', () => {
+    const labelA = 'b321a'
+    const labelB = 'b321b'
+    const cf = clownface({ dataset: rdf.dataset() })
+
+    const result = cf.blankNode(new Set([labelA, labelB]))
+
+    assert.strictEqual(result._context.length, 2)
+    assert.strictEqual(result._context[0].term.termType, 'BlankNode')
+    assert.strictEqual(result._context[0].term.value, labelA)
+    assert.strictEqual(result._context[1].term.termType, 'BlankNode')
+    assert.strictEqual(result._context[1].term.value, labelB)
+  })
 })

--- a/test/Clownface/literal.js
+++ b/test/Clownface/literal.js
@@ -135,6 +135,18 @@ describe('.literal', () => {
     assert.strictEqual(result._context[1].term.value, '2')
   })
 
+  it('should support multiple values in an iterable', () => {
+    const cf = clownface({ dataset: rdf.dataset() })
+
+    const result = cf.literal(new Set(['1', '2']))
+
+    assert.strictEqual(result._context.length, 2)
+    assert.strictEqual(result._context[0].term.termType, 'Literal')
+    assert.strictEqual(result._context[0].term.value, '1')
+    assert.strictEqual(result._context[1].term.termType, 'Literal')
+    assert.strictEqual(result._context[1].term.value, '2')
+  })
+
   it('should use the given datatype', () => {
     const datatypeIri = 'http://example.org/datatype'
     const cf = clownface({ dataset: rdf.dataset() })

--- a/test/Clownface/namedNode.js
+++ b/test/Clownface/namedNode.js
@@ -1,6 +1,7 @@
 /* global describe, it */
 
 const assert = require('assert')
+const TermSet = require('@rdfjs/term-set')
 const clownface = require('../..')
 const rdf = require('../support/factory')
 const Clownface = require('../../lib/Clownface')
@@ -47,6 +48,32 @@ describe('.namedNode', () => {
     const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.namedNode([iriA, iriB])
+
+    assert.strictEqual(result._context.length, 2)
+    assert.strictEqual(result._context[0].term.termType, 'NamedNode')
+    assert.strictEqual(result._context[0].term.value, iriA)
+    assert.strictEqual(result._context[1].term.termType, 'NamedNode')
+    assert.strictEqual(result._context[1].term.value, iriB)
+  })
+
+  it('should support multiple values from NamedNode iterator', () => {
+    const iriA = rdf.namedNode('http://example.org/a')
+    const iriB = rdf.namedNode('http://example.org/b')
+    const cf = clownface({ dataset: rdf.dataset() })
+
+    const result = cf.namedNode(new TermSet([iriA, iriB]))
+
+    assert.strictEqual(result._context.length, 2)
+    assert.deepStrictEqual(result._context[0].term, iriA)
+    assert.deepStrictEqual(result._context[1].term, iriB)
+  })
+
+  it('should support multiple values from string iterator', () => {
+    const iriA = 'http://example.org/a'
+    const iriB = 'http://example.org/b'
+    const cf = clownface({ dataset: rdf.dataset() })
+
+    const result = cf.namedNode(new Set([iriA, iriB]))
 
     assert.strictEqual(result._context.length, 2)
     assert.strictEqual(result._context[0].term.termType, 'NamedNode')

--- a/test/Clownface/node.js
+++ b/test/Clownface/node.js
@@ -1,6 +1,8 @@
 /* global describe, it */
 
 const assert = require('assert')
+const TermSet = require('@rdfjs/term-set')
+const { xsd } = require('../support/namespace')
 const clownface = require('../..')
 const loadExample = require('../support/example')
 const rdf = require('../support/factory')
@@ -108,6 +110,22 @@ describe('.node', () => {
 
     assert.strictEqual(result._context.length, 1)
     assert.strictEqual(result._context[0].term.termType, 'BlankNode')
+  })
+
+  it('should create nodes from term iterator', () => {
+    const cf = clownface({ dataset: rdf.dataset() })
+    const nodes = new TermSet([
+      rdf.namedNode('http://example.com/'),
+      rdf.literal('10', xsd.int),
+      rdf.blankNode()
+    ])
+
+    const result = cf.node(nodes)
+
+    assert.strictEqual(result._context.length, 3)
+    assert.deepStrictEqual(result._context[0].term, rdf.namedNode('http://example.com/'))
+    assert.deepStrictEqual(result._context[1].term, rdf.literal('10', xsd.int))
+    assert.strictEqual(result._context[2].term.termType, 'BlankNode')
   })
 
   it('should use the given datatype', () => {

--- a/test/support/namespace.js
+++ b/test/support/namespace.js
@@ -8,7 +8,8 @@ const ns = {
   rest: rdf.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'),
   ex: namespace('http://example.org/'),
   rdfs: namespace('http://www.w3.org/2000/01/rdf-schema#'),
-  schema: namespace('http://schema.org/')
+  schema: namespace('http://schema.org/'),
+  xsd: namespace('http://www.w3.org/2001/XMLSchema#')
 }
 
 module.exports = ns


### PR DESCRIPTION
I propose a small change to allow any Iterator as parameter to `node/literal/namedNode/blankNode`

This will be especially useful with `TermSet`. For example in hydra box

```
const types = clownface(req.hydra.api).namedNode(req.hydra.resource.types)
```

Little change but simpler to write and read