### PR TITLE
outE (out edges) and inE (in edges) methods 

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -53,7 +53,9 @@ A graph pointer object, which points at 0..N nodes within a dataset
     * [.literal(values, [languageOrDatatype])](#Clownface+literal) ⇒ [<code>Clownface</code>](#Clownface)
     * [.namedNode(values)](#Clownface+namedNode) ⇒ [<code>Clownface</code>](#Clownface)
     * [.in([predicates])](#Clownface+in) ⇒ [<code>Clownface</code>](#Clownface)
+    * [.inE([predicates])](#Clownface+inE) ⇒ [<code>Clownface</code>](#Clownface)
     * [.out([predicates], [options])](#Clownface+out) ⇒ [<code>Clownface</code>](#Clownface)
+    * [.outE([predicates], [options])](#Clownface+outE) ⇒ [<code>Clownface</code>](#Clownface)
     * [.has(predicates, [objects])](#Clownface+has) ⇒ [<code>Clownface</code>](#Clownface)
     * [.addIn(predicates, subjects, [callback])](#Clownface+addIn) ⇒ [<code>Clownface</code>](#Clownface)
     * [.addOut(predicates, objects, [callback])](#Clownface+addOut) ⇒ [<code>Clownface</code>](#Clownface)
@@ -292,11 +294,53 @@ Creates a graph pointer to nodes which are linked to the current pointer by `pre
     </tr>  </tbody>
 </table>
 
+<a name="Clownface+inE"></a>
+
+### clownface.inE([predicates]) ⇒ [<code>Clownface</code>](#Clownface)
+A similar operation to in, but instead of returning the objects, it returns pointers to the matching predicates
+
+**Kind**: instance method of [<code>Clownface</code>](#Clownface)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th><th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>[predicates]</td><td><code>Term</code> | <code>Array.&lt;Term&gt;</code> | <code><a href="#Clownface">Clownface</a></code> | <code><a href="#Clownface">Array.&lt;Clownface&gt;</a></code></td><td><p>one or more RDF/JS term identifying a property</p>
+</td>
+    </tr>  </tbody>
+</table>
+
 <a name="Clownface+out"></a>
 
 ### clownface.out([predicates], [options]) ⇒ [<code>Clownface</code>](#Clownface)
 Creates a graph pointer to the result nodes after following a predicate, or after
 following any predicates in an array, starting from the subject(s) (current graph pointer) to the objects.
+
+**Kind**: instance method of [<code>Clownface</code>](#Clownface)  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th><th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>[predicates]</td><td><code>Term</code> | <code>Array.&lt;Term&gt;</code> | <code><a href="#Clownface">Clownface</a></code> | <code><a href="#Clownface">Array.&lt;Clownface&gt;</a></code></td><td><p>any predicates to follow</p>
+</td>
+    </tr><tr>
+    <td>[options]</td><td><code>object</code></td><td></td>
+    </tr><tr>
+    <td>[options.language]</td><td><code>string</code> | <code>Array.&lt;string&gt;</code> | <code>undefined</code></td><td></td>
+    </tr>  </tbody>
+</table>
+
+<a name="Clownface+outE"></a>
+
+### clownface.outE([predicates], [options]) ⇒ [<code>Clownface</code>](#Clownface)
+A similar operation to out, but instead of returning the objects, it returns pointers to the matching predicates
 
 **Kind**: instance method of [<code>Clownface</code>](#Clownface)  
 <table>

--- a/lib/Clownface.js
+++ b/lib/Clownface.js
@@ -296,6 +296,19 @@ class Clownface {
   }
 
   /**
+   * A similar operation to in, but instead of returning the objects, it returns pointers to the matching predicates
+   * @param {Term|Term[]|Clownface|Clownface[]} [predicates] one or more RDF/JS term identifying a property
+   * @returns {Clownface}
+   */
+  inE (predicates) {
+    predicates = this._toTermArray(predicates)
+
+    const context = this._context.reduce((all, current) => all.concat(current.inE(predicates)), [])
+
+    return Clownface.fromContext(context)
+  }
+
+  /**
    * Creates a graph pointer to the result nodes after following a predicate, or after
    * following any predicates in an array, starting from the subject(s) (current graph pointer) to the objects.
    * @param {Term|Term[]|Clownface|Clownface[]} [predicates] any predicates to follow
@@ -307,6 +320,21 @@ class Clownface {
     predicates = this._toTermArray(predicates)
 
     const context = this._context.reduce((all, current) => all.concat(current.out(predicates, options)), [])
+
+    return Clownface.fromContext(context)
+  }
+
+  /**
+   * A similar operation to out, but instead of returning the objects, it returns pointers to the matching predicates
+   * @param {Term|Term[]|Clownface|Clownface[]} [predicates] any predicates to follow
+   * @param {object} [options]
+   * @param {string | string[] | undefined} [options.language]
+   * @returns {Clownface}
+   */
+  outE (predicates, options = {}) {
+    predicates = this._toTermArray(predicates)
+
+    const context = this._context.reduce((all, current) => all.concat(current.outE(predicates, options)), [])
 
     return Clownface.fromContext(context)
   }

--- a/lib/Context.js
+++ b/lib/Context.js
@@ -27,6 +27,12 @@ class Context {
     })
   }
 
+  inE (predicate) {
+    return this.matchProperty(null, predicate, toArray(this.term), toArray(this.graph), 'predicate').map(subject => {
+      return this.clone({ value: subject })
+    })
+  }
+
   out (predicate, { language } = {}) {
     let objects = this.matchProperty(toArray(this.term), predicate, null, toArray(this.graph), 'object')
 
@@ -39,6 +45,14 @@ class Context {
 
     return objects.map(object => {
       return this.clone({ value: object })
+    })
+  }
+
+  outE (predicate) {
+    let predicates = this.matchProperty(toArray(this.term), predicate, null, toArray(this.graph), 'predicate')
+
+    return predicates.map(predicate => {
+      return this.clone({ value: predicate })
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clownface",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Simple but powerful graph traversing library",
   "main": "index.js",
   "scripts": {

--- a/test/Clownface/inE.js
+++ b/test/Clownface/inE.js
@@ -1,0 +1,80 @@
+/* global describe, it */
+
+const assert = require('assert')
+const clownface = require('../..')
+const loadExample = require('../support/example')
+const rdf = require('../support/factory')
+const ns = require('../support/namespace')
+const Clownface = require('../../lib/Clownface')
+
+describe('.inE', () => {
+  it('should be a function', () => {
+    const cf = clownface({ dataset: rdf.dataset() })
+
+    assert.strictEqual(typeof cf.inE, 'function')
+  })
+
+  it('should return a new Clownface instance', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      value: '2311 North Los Robles Avenue, Aparment 4A'
+    })
+
+    const result = cf.inE(rdf.namedNode('http://schema.org/streetAddress'))
+
+    assert(result instanceof Clownface)
+    assert.notStrictEqual(result, cf)
+  })
+
+  it('should search object -> subject without predicate', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: ns.tbbtp('bernadette-rostenkowski')
+    })
+
+    const result = cf.inE()
+
+    assert.strictEqual(result._context.length, 8)
+  })
+
+  it('should search object -> subject with predicate', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      value: '2311 North Los Robles Avenue, Aparment 4A'
+    })
+
+    const result = cf.inE(rdf.namedNode('http://schema.org/streetAddress'))
+
+    assert.strictEqual(result._context.length, 2)
+    assert.strictEqual(result._context[0].term.termType, 'NamedNode')
+    assert.strictEqual(result._context[0].term.value, 'http://schema.org/streetAddress')
+  })
+
+  it('should support multiple predicate values in an array', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
+
+    const result = cf.inE([
+      rdf.namedNode('http://schema.org/spouse'),
+      rdf.namedNode('http://schema.org/knows')
+    ])
+
+    assert.strictEqual(result._context.length, 8)
+  })
+
+  it('should support clownface objects as predicates', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
+
+    const result = cf.inE(cf.node([
+      rdf.namedNode('http://schema.org/spouse'),
+      rdf.namedNode('http://schema.org/knows')
+    ]))
+
+    assert.strictEqual(result._context.length, 8)
+  })
+})

--- a/test/Clownface/outE.js
+++ b/test/Clownface/outE.js
@@ -76,5 +76,4 @@ describe('.outE', () => {
 
     assert.strictEqual(result._context.length, 2)
   })
-
 })

--- a/test/Clownface/outE.js
+++ b/test/Clownface/outE.js
@@ -1,0 +1,80 @@
+const { describe, it } = require('mocha')
+const assert = require('assert')
+const clownface = require('../..')
+const loadExample = require('../support/example')
+const rdf = require('../support/factory')
+const Clownface = require('../../lib/Clownface')
+const ns = require('../support/namespace')
+
+describe('.outE', () => {
+  it('should be a function', () => {
+    const cf = clownface({ dataset: rdf.dataset() })
+
+    assert.strictEqual(typeof cf.outE, 'function')
+  })
+
+  it('should return a new Clownface instance', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/amy-farrah-fowler')
+    })
+
+    const result = cf.outE(rdf.namedNode('http://schema.org/jobTitle'))
+
+    assert(result instanceof Clownface)
+    assert.notStrictEqual(result, cf)
+  })
+
+  it('should search subject -> object without predicate', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: ns.tbbtp('amy-farrah-fowler')
+    })
+
+    const result = cf.outE()
+
+    assert.strictEqual(result._context.length, 12)
+  })
+
+  it('should search subject -> predicate with predicate', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/amy-farrah-fowler')
+    })
+
+    const result = cf.outE(rdf.namedNode('http://schema.org/jobTitle'))
+
+    assert.strictEqual(result._context.length, 1)
+    assert.strictEqual(result._context[0].term.termType, 'NamedNode')
+    assert.strictEqual(result._context[0].term.value, 'http://schema.org/jobTitle')
+  })
+
+  it('should support multiple predicate values in an array', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
+
+    const result = cf.outE([
+      rdf.namedNode('http://schema.org/familyName'),
+      rdf.namedNode('http://schema.org/givenName')
+    ])
+
+    assert.strictEqual(result._context.length, 2)
+  })
+
+  it('should support clownface objects as predicates', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
+
+    const result = cf.outE(cf.node([
+      rdf.namedNode('http://schema.org/familyName'),
+      rdf.namedNode('http://schema.org/givenName')
+    ]))
+
+    assert.strictEqual(result._context.length, 2)
+  })
+
+})


### PR DESCRIPTION
Hi,

I was trying to 'follow my nose' and explore properties and objects using clownface, but it was difficult for me to explore 'properties' (for example, to get the label of a property)

I added the outE (out edges) and inE (in edges) methods to experiment. I find them useful. 

This is the inspiration: https://github.com/mpollmeier/gremlin-scala/blob/master/gremlin-scala/src/test/scala/gremlin/scala/ArrowSyntaxSpec.scala

I made this pull request to discuss the addition of these two functions
