### PR TITLE
feat: filtering pointer by language tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI
-on: push
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,8 @@
 <dt><a href="#factory">factory(init)</a> ⇒ <code><a href="#Clownface">Clownface</a></code></dt>
 <dd><p>Factory to create graph pointer objects</p>
 </dd>
+<dt><a href="#filterTaggedLiterals">filterTaggedLiterals(terms, [options])</a> ⇒ <code>Array.&lt;Term&gt;</code></dt>
+<dd></dd>
 </dl>
 
 ## Typedefs
@@ -509,6 +511,26 @@ Factory to create graph pointer objects
     </tr>  </tbody>
 </table>
 
+<a name="filterTaggedLiterals"></a>
+
+## filterTaggedLiterals(terms, [options]) ⇒ <code>Array.&lt;Term&gt;</code>
+**Kind**: global function  
+<table>
+  <thead>
+    <tr>
+      <th>Param</th><th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>terms</td><td><code>Array.&lt;Term&gt;</code></td>
+    </tr><tr>
+    <td>[options]</td><td><code>object</code></td>
+    </tr><tr>
+    <td>[options.language]</td><td><code>string</code> | <code>Array.&lt;string&gt;</code></td>
+    </tr>  </tbody>
+</table>
+
 <a name="GraphPointerCallback"></a>
 
 ## GraphPointerCallback : <code>function</code>
@@ -539,6 +561,10 @@ Factory to create graph pointer objects
   <tbody>
 <tr>
     <td>pointer</td><td><code><a href="#Clownface">Clownface</a></code></td>
+    </tr><tr>
+    <td>index</td><td><code>number</code></td>
+    </tr><tr>
+    <td>pointers</td><td><code><a href="#Clownface">Array.&lt;Clownface&gt;</a></code></td>
     </tr>  </tbody>
 </table>
 

--- a/filter.js
+++ b/filter.js
@@ -1,0 +1,18 @@
+const { filterTaggedLiterals } = require('./lib/languageTag')
+
+/**
+ * Returns a function to be used as callback to `Clownface#filter`.
+ * It will return only literals which match the given `language(s)`
+ *
+ * @param {string | string[]} language
+ * @returns {function(Clownface, number, Clownface[]): boolean}
+ */
+function taggedLiteral (language) {
+  return (current, index, pointers) => {
+    const found = filterTaggedLiterals(pointers.map(ptr => ptr.term), { language })
+
+    return found.some(term => current.term.equals(term))
+  }
+}
+
+module.exports = { taggedLiteral }

--- a/lib/Clownface.js
+++ b/lib/Clownface.js
@@ -198,10 +198,9 @@ class Clownface {
    * @returns {Clownface}
    */
   filter (callback) {
-    const pointers = this.toArray()
+    const pointers = this._context.map(context => Clownface.fromContext(context))
 
-    return Clownface.fromContext(this._context.filter((context, index) =>
-      callback(Clownface.fromContext(context), index, pointers)))
+    return Clownface.fromContext(pointers.filter((pointer, index) => callback(pointer, index, pointers)))
   }
 
   /**

--- a/lib/Clownface.js
+++ b/lib/Clownface.js
@@ -198,7 +198,10 @@ class Clownface {
    * @returns {Clownface}
    */
   filter (callback) {
-    return Clownface.fromContext(this._context.filter(context => callback(Clownface.fromContext(context))))
+    const pointers = this.toArray()
+
+    return Clownface.fromContext(this._context.filter((context, index) =>
+      callback(Clownface.fromContext(context), index, pointers)))
   }
 
   /**
@@ -476,6 +479,8 @@ class Clownface {
 /**
  * @callback FilterCallback
  * @param {Clownface} pointer
+ * @param {number} index
+ * @param {Clownface[]} pointers
  * @return {boolean}
  */
 

--- a/lib/Context.js
+++ b/lib/Context.js
@@ -1,6 +1,6 @@
 const term = require('./term')
 const toArray = require('./toArray')
-const { createLanguageMapper } = require('../lib/languageTag')
+const { filterTaggedLiterals } = require('../lib/languageTag')
 
 class Context {
   constructor ({ dataset, graph, value, factory, namespace }) {
@@ -31,10 +31,7 @@ class Context {
     let objects = this.matchProperty(toArray(this.term), predicate, null, toArray(this.graph), 'object')
 
     if (typeof language !== 'undefined') {
-      const languages = (typeof language === 'string' ? [language] : language)
-      const getLiteralsForLanguage = createLanguageMapper(objects)
-
-      objects = languages.map(getLiteralsForLanguage).find(Boolean) || []
+      objects = filterTaggedLiterals(objects, { language })
     }
 
     return objects.map(object => {

--- a/lib/languageTag.js
+++ b/lib/languageTag.js
@@ -42,6 +42,20 @@ function createLanguageMapper (objects) {
   }
 }
 
+/**
+ *
+ * @param {Term[]} terms
+ * @param {object} [options]
+ * @param {string | string[]} [options.language]
+ * @returns {Term[]}
+ */
+function filterTaggedLiterals (terms, { language }) {
+  const languages = (typeof language === 'string' ? [language] : language)
+  const getLiteralsForLanguage = createLanguageMapper(terms)
+
+  return languages.map(getLiteralsForLanguage).find(Boolean) || []
+}
+
 module.exports = {
-  createLanguageMapper
+  filterTaggedLiterals
 }

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,0 +1,59 @@
+/* global describe, it */
+
+const assert = require('assert')
+const clownface = require('..')
+const { taggedLiteral } = require('../filter')
+const rdf = require('./support/factory')
+const TermSet = require('@rdfjs/term-set')
+
+describe('clownface/filter', () => {
+  describe('.taggedLiteral', () => {
+    it('should return literals for language', async () => {
+      const schemaName = rdf.namedNode('http://schema.org/givenName')
+      const cf = clownface({ dataset: rdf.dataset() })
+        .blankNode()
+        .addOut(schemaName, [
+          rdf.literal('Zurich', 'en'),
+          rdf.literal('Zürich', 'de'),
+          rdf.literal('Zurych', 'pl')])
+        .out(schemaName)
+
+      const result = cf.filter(taggedLiteral(['de']))
+
+      assert(result.term.equals(rdf.literal('Zürich', 'de')))
+    })
+
+    it('should work with multi-pointer', async () => {
+      const containsPlace = rdf.namedNode('http://schema.org/containsPlace')
+      const name = rdf.namedNode('http://schema.org/name')
+      const cf = clownface({ dataset: rdf.dataset() })
+      cf.namedNode('Europe').addOut(containsPlace, [
+        cf.namedNode('CH')
+          .addOut(name, cf.literal('Switzerland', 'en'))
+          .addOut(name, cf.literal('Die Schweiz', 'de')),
+        cf.namedNode('PL')
+          .addOut(name, cf.literal('Poland', 'en'))
+          .addOut(name, cf.literal('Polen', 'de'))
+      ])
+
+      const multi = cf.node([rdf.namedNode('CH'), rdf.namedNode('PL')]).out(name)
+      const result = multi.filter(taggedLiteral(['de']))
+
+      const terms = new TermSet(result.terms)
+      assert.strictEqual(result.terms.length, 2)
+      assert(terms.has(rdf.literal('Die Schweiz', 'de')))
+      assert(terms.has(rdf.literal('Polen', 'de')))
+    })
+
+    it('should ignore non-literals', async () => {
+      const schemaKnows = rdf.namedNode('http://schema.org/knows')
+      const cf = clownface({ dataset: rdf.dataset() })
+        .blankNode()
+        .addOut(schemaKnows, [rdf.blankNode(), rdf.blankNode()])
+
+      const result = cf.out(schemaKnows).filter(taggedLiteral(['de']))
+
+      assert.strictEqual(result.terms.length, 0)
+    })
+  })
+})


### PR DESCRIPTION
- Extends `filter` to allow accessing all pointers.
- Exports a filter function to select only literals matching given language tag(s)

```ts
import { taggedLiteral } from 'clownface/filter'

let allLiteral: MultiPointer

const germanLiterals = allLiterals.filter(taggedLiteral(['de-CH', 'de']))
```

* [ ] update documentation