### PR TITLE
fix: filter would return object with wrong context

### DIFF
--- a/lib/Clownface.js
+++ b/lib/Clownface.js
@@ -200,7 +200,7 @@ class Clownface {
   filter (callback) {
     const pointers = this._context.map(context => Clownface.fromContext(context))
 
-    return Clownface.fromContext(pointers.filter((pointer, index) => callback(pointer, index, pointers)))
+    return Clownface.fromContext(this._context.filter((context, index) => callback(Clownface.fromContext(context), index, pointers)))
   }
 
   /**

--- a/test/Clownface/filter.js
+++ b/test/Clownface/filter.js
@@ -5,6 +5,7 @@ const clownface = require('../..')
 const loadExample = require('../support/example')
 const rdf = require('../support/factory')
 const Clownface = require('../../lib/Clownface')
+const Context = require('../../lib/Context')
 
 describe('.filter', () => {
   it('should be a function', () => {
@@ -17,6 +18,14 @@ describe('.filter', () => {
     const cf = clownface({ dataset: rdf.dataset() })
 
     assert(cf.filter(() => true) instanceof Clownface)
+  })
+
+  it('should return instance with _context of correct type', () => {
+    const cf = clownface({ dataset: rdf.dataset() }).namedNode()
+
+    const [context] = cf.filter(() => true)._context
+
+    assert(context instanceof Context)
   })
 
   it('should call the function with Dataset parameter', async () => {


### PR DESCRIPTION
In #63  I inadvertently introduced a bug where the returned pointer would have `Clownface` objects in `_context` and not instances of `Context`