### PR TITLE
fix: border case for deleteList

### DIFF
--- a/lib/Context.js
+++ b/lib/Context.js
@@ -107,17 +107,32 @@ class Context {
   deleteItems (start) {
     let quads = [start]
 
-    let moreQuads = quads.length
-    while (!quads[quads.length - 1].object.equals(this.namespace.nil) && moreQuads) {
-      const node = quads[quads.length - 1].object
+    // Fail if malformed
+    let lastQuadCount = quads.length
+    let itGrew = true
 
+    while (!quads[quads.length - 1].object.equals(this.namespace.nil) && itGrew) {
+      const checkPred = (pred) => quads[quads.length - 1].predicate.equals(pred)
+      if (lastQuadCount > 1 && !(checkPred(this.namespace.first) || checkPred(this.namespace.rest))) {
+        throw Error('List predicate is either rdf:first or rdf:rest ')
+      }
+
+      const node = quads[quads.length - 1].object
       quads = quads.concat([...this.dataset.match(node)])
-      moreQuads = quads.length - moreQuads
+
+      itGrew = quads.length > lastQuadCount
+      lastQuadCount = quads.length
     }
 
-    quads.forEach(quad => {
-      this.dataset.delete(quad)
-    })
+    const wasNil = quads[quads.length - 1].object.equals(this.namespace.nil)
+
+    if (wasNil) {
+      quads.forEach(quad => {
+        this.dataset.delete(quad)
+      })
+    } else if (lastQuadCount > 1) {
+      throw Error('List ending was not rdf:nil')
+    }
   }
 
   match (subject, predicate, object, graph) {


### PR DESCRIPTION
The following snippet:

```js
  const dataset = rdf.dataset([
    rdf.quad(ns.ex.term, ns.ex.p, ns.ex.list)
  ])
  const cf = clownface({ term: ns.ex.term, dataset })
  cf.deleteList(ns.ex.p)
  ```
  
would make the current version of clownface hang. 

The quick fix I came up with is to check if the list of elements to delete grows or not. (I'm not sure if that's enough)