### PR TITLE
fix: ensure same env

### DIFF
--- a/.changeset/shaggy-buses-sell.md
+++ b/.changeset/shaggy-buses-sell.md
@@ -1,0 +1,5 @@
+---
+"clownface": patch
+---
+
+Fixes a problem that in some scenarios when operating on a `MultiPointer` would use clownface's default environment which causes clashing blank node being generated

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import Clownface from './lib/Clownface.js'
+import environment from './lib/environment.js'
 
 /**
  * Factory to create graph pointer objects
@@ -12,6 +13,6 @@ import Clownface from './lib/Clownface.js'
  * @param {Context} [init._context] an existing clownface context. takes precedence before other params
  * @returns {Clownface}
  */
-export default function factory({ dataset, graph, term, value, factory, _context }) {
+export default function factory({ dataset, graph, term, value, factory = environment, _context }) {
   return new Clownface({ dataset, graph, term, value, factory, _context })
 }

--- a/lib/Clownface.js
+++ b/lib/Clownface.js
@@ -2,13 +2,12 @@ import ns from './namespace.js'
 import toArray from './toArray.js'
 import toTermArray from './toTermArray.js'
 import Context from './Context.js'
-import env from './environment.js'
 
 /**
  * A graph pointer object, which points at 0..N nodes within a dataset
  */
 export default class Clownface {
-  constructor({ dataset, graph, term, value, factory = env, _context }) {
+  constructor({ dataset, graph, term, value, factory, _context }) {
     this.factory = factory
     this.namespace = ns(factory)
 
@@ -106,7 +105,7 @@ export default class Clownface {
    * @returns {Clownface}
    */
   any() {
-    return Clownface.fromContext(this._context.map(current => current.clone({ })))
+    return Clownface.fromContext(this._context.map(current => current.clone({ })), this)
   }
 
   /**
@@ -188,7 +187,7 @@ export default class Clownface {
    */
   toArray() {
     return this._context
-      .map(context => Clownface.fromContext(context))
+      .map(context => Clownface.fromContext(context, this))
       .filter(context => context.terms.some(Boolean))
   }
 
@@ -198,9 +197,9 @@ export default class Clownface {
    * @returns {Clownface}
    */
   filter(callback) {
-    const pointers = this._context.map(context => Clownface.fromContext(context))
+    const pointers = this._context.map(context => Clownface.fromContext(context, this))
 
-    return Clownface.fromContext(this._context.filter((context, index) => callback(Clownface.fromContext(context), index, pointers)))
+    return Clownface.fromContext(this._context.filter((context, index) => callback(Clownface.fromContext(context, this), index, pointers)), this)
   }
 
   /**
@@ -253,7 +252,7 @@ export default class Clownface {
       }, []))
     }, [])
 
-    return Clownface.fromContext(context)
+    return Clownface.fromContext(context, { factory: this.factory })
   }
 
   /**
@@ -294,7 +293,7 @@ export default class Clownface {
 
     const context = this._context.reduce((all, current) => all.concat(current.in(predicates)), [])
 
-    return Clownface.fromContext(context)
+    return Clownface.fromContext(context, this)
   }
 
   /**
@@ -310,7 +309,7 @@ export default class Clownface {
 
     const context = this._context.reduce((all, current) => all.concat(current.out(predicates, options)), [])
 
-    return Clownface.fromContext(context)
+    return Clownface.fromContext(context, this)
   }
 
   /**
@@ -328,7 +327,7 @@ export default class Clownface {
 
     const context = this._context.reduce((all, current) => all.concat(current.has(predicates, objects)), [])
 
-    return Clownface.fromContext(context)
+    return Clownface.fromContext(context, this)
   }
 
   /**
@@ -355,7 +354,7 @@ export default class Clownface {
     const context = this._context.map(context => context.addIn(predicates, subjects))
 
     if (callback) {
-      Clownface.fromContext(context).forEach(callback)
+      Clownface.fromContext(context, this).forEach(callback)
     }
 
     return this
@@ -385,7 +384,7 @@ export default class Clownface {
     const context = this._context.map(context => context.addOut(predicates, objects))
 
     if (callback) {
-      Clownface.fromContext(context).forEach(callback)
+      Clownface.fromContext(context, this).forEach(callback)
     }
 
     return this
@@ -465,8 +464,8 @@ export default class Clownface {
     return toTermArray(predicates, type, languageOrDatatype, this.factory)
   }
 
-  static fromContext(context) {
-    return new Clownface({ _context: toArray(context), factory: context.factory })
+  static fromContext(context, { factory }) {
+    return new Clownface({ _context: toArray(context), factory })
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clownface",
-  "version": "1.5.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clownface",
-      "version": "1.5.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/environment": "^0.1.2"

--- a/test/Clownface/addOut.test.js
+++ b/test/Clownface/addOut.test.js
@@ -182,6 +182,23 @@ describe('.addOut', () => {
     })
   })
 
+  context('multi pointer', () => {
+    it('should reuse current factory', () => {
+      const dataset = rdf.dataset()
+      const predicate = rdf.namedNode('http://schema.org/knows')
+      const term = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
+      const factory = new Environment([NamespaceFactory, CustomDataFactory])
+
+      clownface({ dataset, factory, term })
+        .node([rdf.namedNode('foo'), rdf.namedNode('bar')])
+        .addOut(predicate, 'test')
+
+      dataset.match(null, predicate, null).forEach((quad) => {
+        assert.strictEqual(quad.testProperty, 'test')
+      })
+    })
+  })
+
   it('should not add quads if context is undefined', () => {
     const dataset = rdf.dataset()
     const cf = clownface({ dataset })

--- a/test/Clownface/constructor.test.js
+++ b/test/Clownface/constructor.test.js
@@ -7,14 +7,14 @@ import Clownface from '../../lib/Clownface.js'
 describe('constructor', () => {
   it('should create a Clownface object', () => {
     const dataset = rdf.dataset()
-    const cf = new Clownface({ dataset })
+    const cf = new Clownface({ dataset, factory: rdf })
 
     assert(cf instanceof Clownface)
   })
 
   it('should create an empty context using the given dataset', () => {
     const dataset = rdf.dataset()
-    const cf = new Clownface({ dataset })
+    const cf = new Clownface({ dataset, factory: rdf })
 
     assert.strictEqual(cf._context.length, 1)
     assert.strictEqual(cf._context[0].dataset, dataset)
@@ -25,7 +25,7 @@ describe('constructor', () => {
   it('should create an empty context using the given graph', () => {
     const dataset = rdf.dataset()
     const graph = rdf.namedNode('http://example.org/graph')
-    const cf = new Clownface({ dataset, graph })
+    const cf = new Clownface({ dataset, graph, factory: rdf })
 
     assert.strictEqual(cf._context.length, 1)
     assert.strictEqual(cf._context[0].dataset, dataset)
@@ -36,7 +36,7 @@ describe('constructor', () => {
   it('should create a context using the given term', () => {
     const dataset = rdf.dataset()
     const term = rdf.namedNode('http://example.org/subject')
-    const cf = new Clownface({ dataset, term })
+    const cf = new Clownface({ dataset, term, factory: rdf })
 
     assert.strictEqual(cf._context.length, 1)
     assert.strictEqual(cf._context[0].term, term)
@@ -46,7 +46,7 @@ describe('constructor', () => {
     const dataset = rdf.dataset()
     const termA = rdf.namedNode('http://example.org/subjectA')
     const termB = rdf.namedNode('http://example.org/subjectB')
-    const cf = new Clownface({ dataset, term: [termA, termB] })
+    const cf = new Clownface({ dataset, term: [termA, termB], factory: rdf })
 
     assert.strictEqual(cf._context.length, 2)
     assert.strictEqual(cf._context[0].term, termA)
@@ -56,7 +56,7 @@ describe('constructor', () => {
   it('should create a context using the given value', () => {
     const dataset = rdf.dataset()
     const value = 'abc'
-    const cf = new Clownface({ dataset, value })
+    const cf = new Clownface({ dataset, value, factory: rdf })
 
     assert.strictEqual(cf._context.length, 1)
     assert.strictEqual(cf._context[0].term.termType, 'Literal')
@@ -67,7 +67,7 @@ describe('constructor', () => {
     const dataset = rdf.dataset()
     const valueA = 'abc'
     const valueB = 'bcd'
-    const cf = new Clownface({ dataset, value: [valueA, valueB] })
+    const cf = new Clownface({ dataset, value: [valueA, valueB], factory: rdf })
 
     assert.strictEqual(cf._context.length, 2)
     assert.strictEqual(cf._context[0].term.termType, 'Literal')
@@ -82,7 +82,7 @@ describe('constructor', () => {
     const termB = rdf.namedNode('http://example.org/subjectB')
     const valueA = 'abc'
     const valueB = 'bcd'
-    const cf = new Clownface({ dataset, term: [termA, termB], value: [valueA, valueB] })
+    const cf = new Clownface({ dataset, term: [termA, termB], value: [valueA, valueB], factory: rdf })
 
     assert.strictEqual(cf._context.length, 2)
     assert.strictEqual(cf._context[0].term, termA)
@@ -92,7 +92,7 @@ describe('constructor', () => {
   it('should use the given _context', () => {
     const dataset = rdf.dataset()
     const term = rdf.namedNode('http://example.org/subject')
-    const cf = new Clownface({ dataset, term })
+    const cf = new Clownface({ dataset, term, factory: rdf })
     const clone = new Clownface(cf)
 
     assert.strictEqual(clone._context, cf._context)
@@ -112,8 +112,8 @@ describe('constructor', () => {
   it('should prioritize _context over term', () => {
     const dataset = rdf.dataset()
     const term = rdf.namedNode('http://example.org/subject')
-    const cf = new Clownface({ dataset, term })
-    const clone = new Clownface({ term, _context: cf._context })
+    const cf = new Clownface({ dataset, term, factory: rdf })
+    const clone = new Clownface({ term, _context: cf._context, factory: rdf })
 
     assert.strictEqual(clone._context, cf._context)
   })
@@ -124,7 +124,7 @@ describe('constructor', () => {
     let error = null
 
     try {
-      Boolean(new Clownface({ dataset, value: new RegExp() }))
+      Boolean(new Clownface({ dataset, value: new RegExp(), factory: rdf }))
     } catch (err) {
       error = err
     }


### PR DESCRIPTION
The problem lied in `Clownface` constructor falling back to the default environment.

In cases when a clownface object pointed at multiple nodes, the caller's factory would be ignored and the default used. That easily led to clashing blank nodes 

The fix is to always reuse the caller's blank node and the default is only used as the initial factory when using clownface directly, without RDF/JS environment